### PR TITLE
fix: resolve CORS 404 errors and add Vercel sub-path routing

### DIFF
--- a/backend/.env.production
+++ b/backend/.env.production
@@ -12,4 +12,4 @@ GOOGLE_CLIENT_ID=your-production-google-client-id.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-production-google-client-secret
 
 # CORS Configuration
-FRONTEND_URL=https://your-vercel-app-url.vercel.app
+FRONTEND_URL=https://sbcc-financial-system.vercel.app

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,14 @@
     }
   },
   "rewrites": [
+    { "source": "/api/auth/:path*", "destination": "/api/auth" },
+    { "source": "/api/collections/:path*", "destination": "/api/collections" },
+    { "source": "/api/expenses/:path*", "destination": "/api/expenses" },
+    { "source": "/api/budget/:path*", "destination": "/api/budget" },
+    { "source": "/api/forms/:path*", "destination": "/api/forms" },
+    { "source": "/api/google-sheets/:path*", "destination": "/api/google-sheets" },
+    { "source": "/api/custom-fields/:path*", "destination": "/api/custom-fields" },
+    { "source": "/api/webhooks/:path*", "destination": "/api/webhooks" },
     {
       "source": "/((?!api/).*)",
       "destination": "/index.html"


### PR DESCRIPTION
- Set correct FRONTEND_URL in backend/.env.production so Railway allows requests from the Vercel frontend domain
- Add explicit sub-path rewrites in vercel.json so /api/auth/login, /api/auth/google/config, etc. route to their serverless function files rather than returning 404 (needed for Vercel-native architecture)